### PR TITLE
Updated sphinx-relay to version 2.2.9

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,8 @@
 id: sphinx-relay
 title: Sphinx Chat
-version: 2.2.7
+version: 2.2.9
 release-notes: |
-  Updates to release tag v2.2.7, details here: https://github.com/stakwork/sphinx-relay/releases/tag/v2.2.7
+  Updates to release tag v2.2.9, details here: https://github.com/stakwork/sphinx-relay/releases/tag/v2.2.9
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/sphinx-relay-wrapper"
 upstream-repo: "https://github.com/stakwork/sphinx-relay"


### PR DESCRIPTION
2.2.9: 
- fix boosts, replies, and direct payments from tribe admin

2.2.8: 
- direct payments in tribes
- fix "forwarded" payment listing in tx list for tribe admin

